### PR TITLE
Do not dispatch a searchAction if searchString === "" ?

### DIFF
--- a/src/reduxSearch.js
+++ b/src/reduxSearch.js
@@ -77,7 +77,10 @@ export default function reduxSearch ({
               resources: resource,
               state: nextState
             }))
-            store.dispatch(actions.search(resourceName)(searchString))
+            
+            if(searchString !== '') {
+              store.dispatch(actions.search(resourceName)(searchString))
+            }
           }
         }
       })


### PR DESCRIPTION
Hi, 

First, thanks a lot for this amazing library. 

I'm using it in my app, and i'm running on this issue, if i am on an unrelated part of the app, where there is no search, and i update the entities of the index, the index get rebuilt. This is a normal behaviour. 

But in the redux dev tools i see a search action for each time the index get rebuilt, and this shouldn't happen as i'm not performing any search there.

What do you think ? Maybe this change will conflict with some use case i didn't think about .

